### PR TITLE
fix blanket tax not applied in live but applied in sandbox - add item…

### DIFF
--- a/typescript/src/shared/prompts.ts
+++ b/typescript/src/shared/prompts.ts
@@ -9,8 +9,9 @@ High level: detail, invoicer, primary_recipients, items, amount are required jso
 
 Below are the required parameters to input referencing the json payload below:
 invoicer.email_address (email address), primary_recipients[0].billing_info.email_address (recipient's email address), items[0].name (product name), items[0].unit_amount.value (product cost),
-amount.breakdown.tax.percent (tax percent), amount.breakdown.discount.invoice_discount.percent (discount)
+items[0].tax.percent (tax percent), amount.breakdown.discount.invoice_discount.percent (discount)
 
+Add tax for each item and not in custom breakdown.
 only apply discount here: amount.breakdown.discount.invoice_discount.percent and not here: items[0].discount.percent unless user says item/product specific discount.
 Also specific amount must be double or integer.
 Below are the parameters you need to take care of:
@@ -74,9 +75,6 @@ Below is the payload request structure:
                 "invoice_discount": {
                     "percent": 0
                 }
-            },
-            "tax": {
-                "percent": 0
             }
         }
     }


### PR DESCRIPTION
* Changes:
  - fix blanket tax not applied in live but applied in sandbox - add item level tax
  - Tax percent is now applied for each item rather than custom.breakdown field since custom.breakdown field intermittently fails.  (a + b ...) * 0.15 = a * 0.15 + b * 0.15 + ....
## E2E Test in Production:

- **Hot fix in process**: Sandbox and production have different behaviors for the same request.

---

- create invoice for 1 pack of walnuts for 2, 1 pack of peanuts for 5 with 10% blanket discount and 15% taxes only with my email address as [kumartheashwani+business@gmail.com](mailto:kumartheashwani+business@gmail.com) and recipient email as [rishabhsharma1708@gmail.com](mailto:rishabhsharma1708@gmail.com).

[Invoice Link](https://www.paypal.com/invoice/p/#INV2-8XE2-LA7Z-VHS9-YLM8)

---

- create invoice for 1 pack 3$ peanuts, 1 pack of walnuts for $2, 1 pack pistachio worth $10 with my email address as [kumartheashwani+business@gmail.com](mailto:kumartheashwani+business@gmail.com) and recipient email as [rishabhsharma1708@gmail.com](mailto:rishabhsharma1708@gmail.com). Only apply 10% discount on walnuts.

[Invoice Link](https://www.paypal.com/invoice/p/#INV2-R7LC-ZXGP-ACXV-CNGF)

---

- create invoice for 1 pack of walnuts for $2 with 10% discount fixed with my email address as [kumartheashwani+business@gmail.com](mailto:kumartheashwani+business@gmail.com) and recipient email as [rishabhsharma1708@gmail.com](mailto:rishabhsharma1708@gmail.com).

[Invoice Link](https://www.paypal.com/invoice/p/#INV2-73G7-NYWR-PKHD-9SQD)

---

- create invoice for 1 pack of walnuts for $2, 1 pack of peanuts for 5$ with 10% discount applied on walnuts only with my email address as [kumartheashwani+business@gmail.com](mailto:kumartheashwani+business@gmail.com) and recipient email as [rishabhsharma1708@gmail.com](mailto:rishabhsharma1708@gmail.com).

[Invoice Link](https://www.paypal.com/invoice/p/#INV2-6N5K-YSGA-S2ZF-GTB4)

---

- create invoice for 1 pack of walnuts for $2, 1 pack of peanuts for 5$ with 10% blanket discount and 15% taxes only with my email address as [kumartheashwani+business@gmail.com](mailto:kumartheashwani+business@gmail.com) and recipient email as [rishabhsharma1708@gmail.com](mailto:rishabhsharma1708@gmail.com).

[Invoice Link](https://www.paypal.com/invoice/p/#INV2-YBT4-E6GU-J4WP-PVQ6)
