### PR TITLE
Correct spelling of GitHub Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ main().catch((error) => {
 });
 ```
 
-### Usage with MCP host (Claude Desktop/Cline/Cursor/Github Co-Pilot)
+### Usage with MCP host (Claude Desktop/Cline/Cursor/GitHub Copilot)
 
 This guide explains how to integrate the PayPal connector with Claude Desktop.
 

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -11,7 +11,7 @@ npx -y @paypal/mcp --tools=all PAYPAL_ACCESS_TOKEN="YOUR_ACCESS_TOKEN" PAYPAL_EN
 
 Replace `YOUR_ACCESS_TOKEN` with your PayPal access token. Refer this on how to [generate a PayPal access token](#generating-an-access-token). Alternatively, you could set the PAYPAL_ACCESS_TOKEN in your environment variables.
 
-### Usage with MCP host (Claude Desktop/Cline/Cursor/Github Co-Pilot)
+### Usage with MCP host (Claude Desktop/Cline/Cursor/GitHub Copilot)
 
 This guide explains how to integrate the PayPal connector with Claude Desktop.
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -175,7 +175,7 @@ main().catch((error) => {
 });
 ```
 
-### Usage with MCP host (Claude Desktop/Cline/Cursor/Github Co-Pilot)
+### Usage with MCP host (Claude Desktop/Cline/Cursor/GitHub Copilot)
 
 This guide explains how to integrate the PayPal connector with Claude Desktop.
 


### PR DESCRIPTION
Updated the spelling of Github Co-Pilot -> GitHub Copilot