### PR TITLE
Remove send invoice from create invoice tool

### DIFF
--- a/python/paypal_agent_toolkit/shared/invoices/tool_handlers.py
+++ b/python/paypal_agent_toolkit/shared/invoices/tool_handlers.py
@@ -7,38 +7,15 @@ from typing import Union, Dict, Any
 
 
 
-def _submit_invoice(client, invoice_payload: dict):
-    url = "/v2/invoicing/invoices"
-    response = client.post(uri=url, payload=invoice_payload)
-
-    if (
-        response.get("rel") == "self"
-        and "/v2/invoicing/invoices/" in response.get("href", "")
-        and response.get("method") == "GET"
-    ):
-        invoice_id = response["href"].split("/")[-1]
-        try:
-            send_result = send_invoice(client, {
-                "invoice_id": invoice_id,
-                "note": "Thank you for choosing us. If there are any issues, feel free to contact us.",
-                "send_to_recipient": True
-            })
-            return json.dumps({
-                "createResult": response,
-                "sendResult": send_result
-            })
-        except Exception:
-            return json.dumps(response)
-
-    return json.dumps(response)
-
-
 def create_invoice(client, params: dict):
 
     validated = CreateInvoiceParameters(**params)
     invoice_payload = build_create_invoice_payload(validated.model_dump(exclude_none=True))
 
-    return _submit_invoice(client, invoice_payload)
+    url = "/v2/invoicing/invoices"
+    response = client.post(uri=url, payload=invoice_payload)
+
+    return json.dumps(response)
 
 
 def send_invoice(client, params: dict):

--- a/typescript/src/shared/functions.ts
+++ b/typescript/src/shared/functions.ts
@@ -79,39 +79,7 @@ export async function createInvoice(
     const invoicePayload = buildCreateInvoicePayload(params);
     const response = await axios.post(url, invoicePayload, { headers });
     logger(`[createInvoice] Invoice created successfully. Status: ${response.status}`);
-
-    // Check if response matches the expected format for a successful invoice creation
-    if (response.data && response.data.rel === 'self' &&
-      response.data.href && response.data.href.includes('/v2/invoicing/invoices/') &&
-      response.data.method === 'GET') {
-
-      // Extract invoice ID from the href URL
-      const hrefParts = response.data.href.split('/');
-      const invoiceId = hrefParts[hrefParts.length - 1];
-
-      // Automatically send the invoice with specific parameters
-      logger('[createInvoice] Automatically sending invoice with thank you note');
-      try {
-        const sendResult = await sendInvoice(client, context, {
-          invoice_id: invoiceId,
-          note: "thank you for choosing us. If there are any issues, feel free to contact us",
-          send_to_recipient: true
-        });
-
-        // Return both the create and send results
-        return {
-          createResult: response.data,
-          sendResult: sendResult
-        };
-      } catch (sendError: any) {
-        logger('[createInvoice] Error in auto-send invoice:', sendError.message);
-        // Still return the original creation result even if sending fails
-        return response.data;
-      }
-    } else {
-      logger(`[createInvoice] Invoice ID: ${response.data.id || 'N/A'}`);
-      return response.data;
-    }
+    return response.data;
   } catch (error: any) {
     logger('[createInvoice] Error creating invoice:', error.message);
     handleAxiosError(error);


### PR DESCRIPTION
## What changed

`create_invoice` was internally calling the send-invoice endpoint (`POST /v2/invoicing/invoices/{id}/send`) immediately after creating a draft, with `send_to_recipient: true` hardcoded — regardless of whether the caller wanted the invoice sent. This meant that in any deployment where an integrator scoped their configuration to `create` only (e.g. `actions.invoices.send: false`, exposing just `create_invoice` and not `send_invoice`), a single `create_invoice` call would still transition the invoice out of draft and email the recipient.
 
The `actions`/`isToolAllowed` permission model only controls which *tools* are listed to the caller — it was never consulted inside `createInvoice`'s implementation, so restricting `send` had no effect on this internal call path.
 
## Fix
 
- `typescript/src/shared/functions.ts`: `createInvoice` now returns the create response directly. Removed the internal `sendInvoice` call and the `{createResult, sendResult}` wrapper shape.
- `python/paypal_agent_toolkit/shared/invoices/tool_handlers.py`: removed the `_submit_invoice` helper; `create_invoice` now posts and returns the draft directly, with no internal `send_invoice` call.
`create_invoice` now does exactly what its `actions: { invoices: { create: true } }` declaration and tool description already promise — creates a draft invoice only. Sending remains an explicit, separate `send_invoice` call, so administrators who disable `send` get an actual create-only boundary.
 
## Behavioral change
 
Integrators who relied on `create_invoice` implicitly sending the invoice will now need to follow up with an explicit `send_invoice` call. This is intentional — it restores the create/send separation PayPal's API already exposes.