### PR TITLE
fix(python): use the default context when none is configured

### DIFF
--- a/python/paypal_agent_toolkit/bedrock/toolkit.py
+++ b/python/paypal_agent_toolkit/bedrock/toolkit.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Any
 from pydantic import PrivateAttr
 from ..shared.api import PayPalAPI
 from ..shared.tools import tools
-from ..shared.configuration import Configuration, is_tool_allowed
+from ..shared.configuration import Configuration, Context, is_tool_allowed
 
 class BedrockTool:
     def __init__(self, name: str, description: str, inputSchema: Dict[str, Any]):
@@ -36,7 +36,7 @@ class PayPalToolkit:
     def __init__(self, client_id, secret, configuration: Configuration):
         super().__init__()
         self.configuration = configuration
-        self.context = configuration.context if configuration and configuration.context else Configuration.Context.default()
+        self.context = configuration.context if configuration and configuration.context else Context.default()
         self.context.source = self.SOURCE
         self._paypal_api = PayPalAPI(client_id=client_id, secret=secret, context=self.context)
 
@@ -68,4 +68,3 @@ class PayPalToolkit:
             )
         except Exception as e:
             print(f"Error handling tool call: {e}")
-            

--- a/python/paypal_agent_toolkit/crewai/toolkit.py
+++ b/python/paypal_agent_toolkit/crewai/toolkit.py
@@ -7,7 +7,7 @@ from pydantic import PrivateAttr, BaseModel
 
 from ..shared.api import PayPalAPI
 from ..shared.tools import tools
-from ..shared.configuration import Configuration, is_tool_allowed
+from ..shared.configuration import Configuration, Context, is_tool_allowed
 from .tool import PayPalTool
 
 
@@ -19,7 +19,7 @@ class PayPalToolkit:
     ):
         super().__init__()
         self._tools = []
-        self.context = configuration.context if configuration and configuration.context else Configuration.Context.default()
+        self.context = configuration.context if configuration and configuration.context else Context.default()
         self.context.source = self.SOURCE
         paypal_api = PayPalAPI(client_id=client_id, secret=secret, context=self.context)
 

--- a/python/paypal_agent_toolkit/langchain/toolkit.py
+++ b/python/paypal_agent_toolkit/langchain/toolkit.py
@@ -17,7 +17,7 @@ class PayPalToolkit:
     def __init__(self, client_id, secret, configuration: Configuration):
         super().__init__()
         self.configuration = configuration
-        self.context = configuration.context if configuration and configuration.context else Configuration.Context.default()
+        self.context = configuration.context if configuration and configuration.context else Context.default()
         self.context.source = self.SOURCE
         self._paypal_api = PayPalAPI(client_id=client_id, secret=secret, context=self.context)
 

--- a/python/paypal_agent_toolkit/openai/toolkit.py
+++ b/python/paypal_agent_toolkit/openai/toolkit.py
@@ -5,7 +5,7 @@ from pydantic import PrivateAttr
 from ..shared.tools import tools
 from ..openai.tool import PayPalTool
 from ..shared.paypal_client import PayPalClient
-from ..shared.configuration import Configuration, is_tool_allowed
+from ..shared.configuration import Configuration, Context, is_tool_allowed
 from ..shared.api import PayPalAPI
 
 class PayPalToolkit:
@@ -18,7 +18,7 @@ class PayPalToolkit:
     def __init__(self, client_id, secret, configuration: Configuration):
         self.configuration = configuration
         
-        self.context = configuration.context if configuration and configuration.context else Configuration.Context.default()
+        self.context = configuration.context if configuration and configuration.context else Context.default()
         self.context.source = self.SOURCE
         self._paypal_api = PayPalAPI(client_id=client_id, secret=secret, context=self.context)
 


### PR DESCRIPTION
## Summary

The Python toolkits currently try to call `Configuration.Context.default()` when `Configuration.context` is omitted or `None`. `Context` is a module-level class rather than an attribute of `Configuration`, so toolkit construction raises `AttributeError` before any PayPal request is made.

This change uses `Context.default()` in the OpenAI, LangChain, CrewAI, and Bedrock adapters. Caller-provided contexts and each adapter's source label remain unchanged.

## Testing

- Compiled the Python package with `compileall`.
- Instantiated all four affected toolkits with `context=None` without making network requests and verified the default context and adapter-specific source.
