### PR TITLE
Fix incorrect PayPal API base URL (use api-m. instead of api.)

### DIFF
--- a/typescript/src/shared/client.ts
+++ b/typescript/src/shared/client.ts
@@ -47,8 +47,8 @@ class PayPalClient {
         }
 
         this._baseUrl = this._isSandbox
-        ? 'https://api.sandbox.paypal.com'
-        : 'https://api.paypal.com';
+        ? 'https://api-m.sandbox.paypal.com'
+        : 'https://api-m.paypal.com';
 
         logger(`[PayPal Setttings] Environment: ${this._isSandbox ? "Sandbox" : "Live"}`);
         logger(`[PayPal Setttings] API Base: ${this._baseUrl}`);


### PR DESCRIPTION
Fixes #43

`PayPalClient` was building request URLs against `api.paypal.com` /
`api.sandbox.paypal.com`. Per PayPal's own docs, REST API calls should
target `api-m.paypal.com` / `api-m.sandbox.paypal.com` — the `api.`
host is only meant as an IP-allowlisting fallback and has higher
latency and lower availability than `api-m.`:
https://developer.paypal.com/api/make-api-requests/

This also brings `client.ts` in line with the rest of this repo's own
README, which already uses `api-m.` in all its OAuth/curl examples.

This is a one-line change to the two base URL strings in
`getBaseUrl()` — no behavior change beyond hitting the correct/
recommended PayPal endpoint. `getBaseUrl()` is used for every REST
call the toolkit makes (invoices, orders, disputes, subscriptions,
tracking, OAuth token fetch), so all of them now go through
`api-m.`.