### PR TITLE
Fix incorrect MCP Inspector command in README

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -220,7 +220,7 @@ The PayPal [Model Context Protocol](https://modelcontextprotocol.com/) server al
 To run the PayPal MCP server using npx, use the following command:
 
 ```bash
-npx -y @paypal/mcp --tools=all PAYPAL_ACCESS_TOKEN="YOUR_ACCESS_TOKEN" PAYPAL_ENVIRONMENT="SANDBOX"
+npx -y @paypal/mcp --tools=all --access-token="YOUR_ACCESS_TOKEN" --paypal-environment="SANDBOX"
 ```
 
 Replace `YOUR_ACCESS_TOKEN` with active access token generated using these steps: [PayPal access token](#generating-an-access-token). Alternatively, you could set the PAYPAL_ACCESS_TOKEN in your environment variables.


### PR DESCRIPTION
Fixes #65

Updated the "Running MCP Inspector" command to use the flags the
CLI actually accepts (--access-token, --paypal-environment) instead
of the PAYPAL_ACCESS_TOKEN / PAYPAL_ENVIRONMENT env-var names, which
throw:

    Invalid argument: PAYPAL_ACCESS_TOKEN. Accepted arguments are: access-token, tools, paypal-environment