### PR TITLE
fix(deps): bump langchain and crewai-tools to patch disclosed CVEs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "openai-agents==0.0.2",
-    "langchain==0.3.23",
-    "crewai-tools==0.13.2",
+    "langchain==1.3.9",
+    "crewai-tools==1.15.1",
     "httpx>=0.26.0",
     "requests>=2.31.0",
     "python-dotenv>=1.0.1",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -15,13 +15,13 @@ openai==1.66.0
 openai-agents==0.0.2
 
 # LangChain
-langchain==0.3.23
+langchain==1.3.9
 langchain-openai==0.2.2
 
 # CrewAI
 setuptools>=61.0
 crewai==0.76.2
-crewai-tools==0.13.2
+crewai-tools==1.15.1
 
 # Amazon Bedrock
 boto3==1.39.11


### PR DESCRIPTION
Automated dependency bump to address disclosed CVEs in the Python package's
declared runtime dependencies (`python/pyproject.toml` / `python/requirements.txt`).

- **langchain** `0.3.23` -> `1.3.9`
  - **Advisory:** [PYSEC-2026-2192](https://github.com/pypa/advisory-database/blob/main/vulns/langchain/PYSEC-2026-2192.yaml) (fixed in 1.3.9)
  - **Advisory:** [GHSA-gr75-jv2w-4656](https://github.com/advisories/GHSA-gr75-jv2w-4656) - path traversal and sandbox escape in LangChain file-search middleware and loaders (fixed in 1.3.9)
- **crewai-tools** `0.13.2` -> `1.15.1`
  - **Advisory:** [GHSA-mr4r-hcgx-8p4h](https://github.com/advisories/GHSA-mr4r-hcgx-8p4h) - SSRF redirect bypass exposes internal services (fixed in 1.15.1, CVSS 3.1 base ~7.5)

Both packages only ship the fix on a newer major line, so this is a
**breaking-version bump**, not a patch-level one. No code changes are
included beyond the manifest/requirements pins - `crewai==0.76.2` and
`langchain-openai==0.2.2` are left untouched, so CI may need a follow-up
compatibility pass (langchain 1.x restructured several import paths, and
`crewai-tools` 1.15.1 may expect a newer `crewai`) before merge.

### Verification
- Reproduced locally: yes (dependency-CVE identification only, no code path exercised)
- Command: `osv-scanner scan source --recursive --no-ignore --format=json python/requirements.txt`
- Before: `langchain==0.3.23` and `crewai-tools==0.13.2` flagged for the advisories above
- After: pins updated to the first fixed release in each advisory's affected range
- Environment: osv-scanner 2.5.1

Detected by [osv-scanner](https://google.github.io/osv-scanner/) as part of an automated dependency-CVE audit; both packages are declared runtime `dependencies` in `python/pyproject.toml`, not dev/example-only pins.